### PR TITLE
Remove 'display' column from country code List

### DIFF
--- a/lib/SongsToTheSiren/Table/Country/List.pm
+++ b/lib/SongsToTheSiren/Table/Country/List.pm
@@ -19,14 +19,6 @@ has_column name => ();
 
 has_column emoji => ();
 
-has_column display => (
-    content => sub {
-        my ($col, $table, $row) = @_;
-
-        return $row->emoji;
-    }
-);
-
 has_column edit => (
     content => sub {
         my ($col, $table, $row) = @_;


### PR DESCRIPTION
Didn't actually need to change the create/edit
page in the end, just fix the country-list table.